### PR TITLE
Add fallback to support coffeescript 1.x

### DIFF
--- a/src/ScopeLinter.coffee
+++ b/src/ScopeLinter.coffee
@@ -143,7 +143,8 @@ module.exports = class ScopeLinter
         # a named class produces a variable in the local scope and in this
         # regard acts like an assignment statement
         if node.variable? and node.variable.isAssignable()
-            if node.variable.shouldCache()
+            # fallback to support coffeescript 1.x
+            if node.variable.shouldCache?() or node.variable.isComplex?()
                 # composite class definition; treat as a read for base value
                 @visit(node.variable)
             else


### PR DESCRIPTION
As mentioned in https://github.com/za-creature/coffeescope/issues/31#issuecomment-335635323, it seems there's only one small fallback needed to support coffee 1.0 codebases.

(coffeescope's been a really useful part of @lever's coffeescript development...and we still have a lot of coffeescript 1.0 code 😓)